### PR TITLE
Restrict to single file upload

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -27,9 +27,9 @@ export default function HomePage() {
     const formData = new FormData();
     formData.append("title", title);
     formData.append("description", description);
-    files.forEach((file) => {
-      formData.append("media[]", file);
-    });
+    if (files[0]) {
+      formData.append("file", files[0]);
+    }
 
     console.log("📤 Sending POST request:", {
       url: "http://localhost:8000/publish/",

--- a/src/components/MediaUploader.tsx
+++ b/src/components/MediaUploader.tsx
@@ -25,17 +25,17 @@ export default function MediaUploader({ files, setFiles }: Props) {
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) return;
-    const newFiles = Array.from(e.target.files);
-    setFiles((prev) => [...prev, ...newFiles]);
-    console.log("📥 Selected files:", newFiles.map((f) => f.name));
+    const newFiles = Array.from(e.target.files).slice(0, 1);
+    setFiles(newFiles);
+    console.log("📥 Selected file:", newFiles.map((f) => f.name));
   };
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     setIsDragOver(false);
-    const droppedFiles = Array.from(e.dataTransfer.files);
-    setFiles((prev) => [...prev, ...droppedFiles]);
-    console.log("📥 Dropped files:", droppedFiles.map((f) => f.name));
+    const droppedFiles = Array.from(e.dataTransfer.files).slice(0, 1);
+    setFiles(droppedFiles);
+    console.log("📥 Dropped file:", droppedFiles.map((f) => f.name));
   };
 
   const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
@@ -71,7 +71,6 @@ export default function MediaUploader({ files, setFiles }: Props) {
         <input
           type="file"
           accept="image/*,video/*"
-          multiple
           onChange={handleFileChange}
           className="hidden"
         />


### PR DESCRIPTION
## Summary
- send only a single file in the Home page form
- limit `MediaUploader` to accept just one file at a time

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843ef5266408332998adea209c82de7