### PR TITLE
Fix hashtag spacing

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -96,11 +96,19 @@ export default function HomePage() {
 
   const handleHashtagUpdate = (tags: string[]) => {
     const cleaned = description
-      .split(" ")
-      .filter((word) => !word.startsWith("#"))
-      .join(" ").trim();
+      .replace(/\s*#\S+/g, "")
+      .trimEnd();
 
-    const newDesc = `${cleaned} ${tags.map(t => `#${t}`).join(" ")}`.trim();
+    if (tags.length === 0) {
+      setDescription(cleaned);
+      return;
+    }
+
+    const hashtags = tags.map(t => `#${t}`).join(" ");
+    const newDesc = cleaned
+      ? `${cleaned}\n\n${hashtags}`
+      : hashtags;
+
     setDescription(newDesc);
   };
 


### PR DESCRIPTION
## Summary
- adjust `handleHashtagUpdate` to insert two line breaks before hashtags
- ensure old hashtags are stripped cleanly

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844185406148332a8e6b01180ee0701